### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new , :create]
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,27 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "############" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image , class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <% if ???????????????????????????%> %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +157,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items %>
       <li class='list'>
         <%= link_to '########################' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +177,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,27 +128,47 @@
     </div>
     <ul class='item-lists'>
 
+<<<<<<< Updated upstream
       <% @items.each do |item| %>
+=======
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item|%>
+>>>>>>> Stashed changes
       <li class='list'>
         <%= link_to "############" do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+<<<<<<< Updated upstream
           <%# <% if ???????????????????????????%> %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>
+=======
+          <% if "条件"%>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <% end %>
+>>>>>>> Stashed changes
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
+<<<<<<< Updated upstream
             <%= item.name %>
           </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.charge.name %></span>
+=======
+            <%= "商品名item.name" %>
+          </h3>
+          <div class='item-price'>
+            <span><%= "販売価格item.price" %>円<br><%= '配送料負担item.charge_id' %></span>
+>>>>>>> Stashed changes
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -158,6 +178,10 @@
         <% end %>
       </li>
       <% end %>
+<<<<<<< Updated upstream
+=======
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+>>>>>>> Stashed changes
 
       <% unless @items %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,6 +128,8 @@
     </div>
     <ul class='item-lists'>
 
+    <% if @items.exists? %>
+    
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "############" do %>
@@ -161,7 +163,8 @@
       </li>
       <% end %>
 
-      <% unless @items %>
+      <% else %>
+
       <li class='list'>
         <%= link_to '########################' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,47 +128,29 @@
     </div>
     <ul class='item-lists'>
 
-<<<<<<< Updated upstream
       <% @items.each do |item| %>
-=======
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% @items.each do |item|%>
->>>>>>> Stashed changes
       <li class='list'>
         <%= link_to "############" do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-<<<<<<< Updated upstream
-          <%# <% if ???????????????????????????%> %>
+
+          <%# if ???????????????????????????%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>
-=======
-          <% if "条件"%>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <% end %>
->>>>>>> Stashed changes
+
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-<<<<<<< Updated upstream
             <%= item.name %>
           </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.charge.name %></span>
-=======
-            <%= "商品名item.name" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格item.price" %>円<br><%= '配送料負担item.charge_id' %></span>
->>>>>>> Stashed changes
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -178,10 +160,6 @@
         <% end %>
       </li>
       <% end %>
-<<<<<<< Updated upstream
-=======
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
->>>>>>> Stashed changes
 
       <% unless @items %>
       <li class='list'>


### PR DESCRIPTION
# what
商品一覧機能の実装

# why
ふたつコンフリクトを起こしてしまいました。
１　あらかじめindexアクションを作ってしまった。
２　ビューファイルをメモがわりに少し編集してからブランチを作ってしまった。
allアクションからincludeに直したつもりですが、なっていなかったらご指摘いただけると助かります。

商品のデータがない場合は、ダミー商品が表示されている
https://gyazo.com/97b66eb1dba1f516b5540c8dceefbea9

商品のデータがある場合は、商品が一覧で表示されている
https://gyazo.com/89cb21d1acbc19fcfe79e227b4dac754